### PR TITLE
add ServiceAccount kube type support

### DIFF
--- a/kubernetes/informer.go
+++ b/kubernetes/informer.go
@@ -149,6 +149,18 @@ func NewInformer(client kubernetes.Interface, resource Resource, opts WatchOptio
 		}
 
 		objType = "service"
+	case *ServiceAccount:
+		sa := client.CoreV1().ServiceAccounts(opts.Namespace)
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return sa.List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return sa.Watch(ctx, options)
+			},
+		}
+
+		objType = "serviceAccount"
 	case *CronJob:
 		cronjob := client.BatchV1().CronJobs(opts.Namespace)
 		listwatch = &cache.ListWatch{

--- a/kubernetes/types.go
+++ b/kubernetes/types.go
@@ -76,6 +76,9 @@ type StatefulSet = appsv1.StatefulSet
 // Service data
 type Service = v1.Service
 
+// ServiceAccount data
+type ServiceAccount = v1.ServiceAccount
+
 // Job data
 type Job = batchv1.Job
 


### PR DESCRIPTION
## What does this PR do?
Adds a new Kubernetes type

## Why is it important?
Cloudbeat's kube fetcher will need to have this type supported.

- see: https://github.com/elastic/beats/pull/31122