### PR TITLE
Add data plane team as code owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# GitHub CODEOWNERS definition
+# See: https://help.github.com/articles/about-codeowners/
+* @elastic/elastic-agent-data-plane


### PR DESCRIPTION
This will auto-assign reviewers like in our other repositories. This is the same code owner config used in libbeat/autodiscover right now.