### PR TITLE
Re order kubernetes node discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.0.0...v0.1.0
+
+
+## [0.6.2]
+
+### Changed
+
+- Usage of env var `NODE_NAME` precedes `machine-id` for kubernetes node discovery.
+
+
+[0.6.2]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.1...v0.6.2

--- a/kubernetes/util.go
+++ b/kubernetes/util.go
@@ -113,8 +113,8 @@ func IsInCluster(kubeconfig string) bool {
 // If host is provided in the config use it directly.
 // If it is empty then try
 // 1. If beat is deployed in k8s cluster, use hostname of pod as the pod name to query pod metadata for node name.
-// 2. If step 1 fails or beat is deployed outside k8s cluster, use machine-id to match against k8s nodes for node name.
-// 3. If node cannot be discovered with step 1,2, fallback to NODE_NAME env var as default value. In case it is not set return error.
+// 2. If step 1 fails or beat is deployed outside k8s cluster, use NODE_NAME env var.
+// 3. If node cannot be discovered with step 1,2, use machine-id to match against k8s nodes for node name. In case it is not set return error.
 func DiscoverKubernetesNode(log *logp.Logger, nd *DiscoverKubernetesNodeParams) (string, error) {
 	ctx := context.TODO()
 	// Discover node by configuration file (NODE) if set
@@ -132,6 +132,14 @@ func DiscoverKubernetesNode(log *logp.Logger, nd *DiscoverKubernetesNodeParams) 
 		log.Debug(err)
 	}
 
+	// use environment variable NODE_NAME
+	node := os.Getenv("NODE_NAME")
+	if node != "" {
+		log.Infof("kubernetes: Node %s discovered by NODE_NAME environment variable", node)
+		return node, nil
+	}
+	log.Debug(errors.New("NODE_NAME environment variable is not set"))
+
 	// try discover node by machine id
 	node, err := discoverByMachineID(nd, ctx)
 	if err == nil {
@@ -139,13 +147,6 @@ func DiscoverKubernetesNode(log *logp.Logger, nd *DiscoverKubernetesNodeParams) 
 		return node, nil
 	}
 	log.Debug(err)
-
-	// fallback to environment variable NODE_NAME
-	node = os.Getenv("NODE_NAME")
-	if node != "" {
-		log.Infof("kubernetes: Node %s discovered by NODE_NAME environment variable", node)
-		return node, nil
-	}
 
 	return "", errors.New("kubernetes: Node could not be discovered with any known method. Consider setting env var NODE_NAME")
 }

--- a/kubernetes/util.go
+++ b/kubernetes/util.go
@@ -115,6 +115,7 @@ func IsInCluster(kubeconfig string) bool {
 // 1. If beat is deployed in k8s cluster, use hostname of pod as the pod name to query pod metadata for node name.
 // 2. If step 1 fails or beat is deployed outside k8s cluster, use NODE_NAME env var.
 // 3. If node cannot be discovered with step 1,2, use machine-id to match against k8s nodes for node name. In case it is not set return error.
+// Note: There have been cases where machine-id reported by compute instances of some cloud providers where k8s nodes run on, has the wrong value.
 func DiscoverKubernetesNode(log *logp.Logger, nd *DiscoverKubernetesNodeParams) (string, error) {
 	ctx := context.TODO()
 	// Discover node by configuration file (NODE) if set

--- a/kubernetes/util_test.go
+++ b/kubernetes/util_test.go
@@ -174,6 +174,17 @@ func TestDiscoverKubernetesNode(t *testing.T) {
 			podname:     "",
 			namespace:   "",
 		},
+		{
+			name:        "test value without inCluster, machine-ID set wrongly, node not found and env var set",
+			host:        "",
+			isInCluster: false,
+			node:        "worker-2",
+			err:         nil,
+			setEnv:      true,
+			machineid:   "worker-1",
+			podname:     "",
+			namespace:   "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR reorders the kubernetes node discovery process. `NODE_NAME` env var will be used to discover the node before machine-id is used. This will fix cases where some cloud provider instances where k8s nodes run on report wrong machine-ids, although the env var is correctly set. The process of discovery will now look like this:

```
// DiscoverKubernetesNode figures out the Kubernetes node to use.
// If host is provided in the config use it directly.
// If it is empty then try
// 1. If beat is deployed in k8s cluster, use hostname of pod as the pod name to query pod metadata for node name.
// 2. If step 1 fails or beat is deployed outside k8s cluster, use NODE_NAME env var.
// 3. If node cannot be discovered with step 1,2, use machine-id to match against k8s nodes for node name. In case it is not set return error.
```

Closes https://github.com/elastic/elastic-agent-autodiscover/issues/39