### PR TITLE
Disable Deployment and Replicaset enrichment by default

### DIFF
--- a/kubernetes/metadata/config.go
+++ b/kubernetes/metadata/config.go
@@ -58,7 +58,7 @@ func GetDefaultResourceMetadataConfig() *AddResourceMetadataConfig {
 	return &AddResourceMetadataConfig{
 		Node:       metaCfg,
 		Namespace:  metaCfg,
-		Deployment: true,
-		CronJob:    true,
+		Deployment: false,
+		CronJob:    false,
 	}
 }

--- a/kubernetes/metadata/pod_test.go
+++ b/kubernetes/metadata/pod_test.go
@@ -345,9 +345,10 @@ func TestPod_Generate(t *testing.T) {
 						"ip":   "127.0.0.5",
 					},
 					"namespace": defaultNs,
-					"deployment": mapstr.M{
-						"name": "nginx-deployment",
-					},
+					// We comment below block because add_resource_metadata.deployment: false by default
+					// "deployment": mapstr.M{
+					// 	"name": "nginx-deployment",
+					// },
 					"replicaset": mapstr.M{
 						"name": "nginx-rs",
 					},
@@ -403,9 +404,10 @@ func TestPod_Generate(t *testing.T) {
 						"ip":   "127.0.0.5",
 					},
 					"namespace": defaultNs,
-					"deployment": mapstr.M{
-						"name": "nginx-deployment",
-					},
+					// We comment below block because add_resource_metadata.deployment: false by default
+					// "deployment": mapstr.M{
+					// 	"name": "nginx-deployment",
+					// },
 					"replicaset": mapstr.M{
 						"name": "nginx-rs",
 					},


### PR DESCRIPTION
Disabling AddResourceMetadataConfig.Deployment: false and AddResourceMetadataConfig.Cronjob: false as per discussion here https://github.com/elastic/elastic-agent-autodiscover/issues/31#issuecomment-1745057020