### PR TITLE
Conditions on podupdater functions of kubernetes autodiscovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 [0.6.2]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.1...v0.6.2
+
+
+## [0.6.6]
+
+### Changed
+
+- Update NewNodePodUpdater and NewNamespacePodUpdater functions to conditionally check and update kubernetes metadata enrichment of pods
+
+
+[0.6.6]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,4 +43,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update NewNodePodUpdater and NewNamespacePodUpdater functions to conditionally check and update kubernetes metadata enrichment of pods
 
 
-[0.6.6]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.7
+[0.6.7]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.6.2]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.1...v0.6.2
 
 
-## [0.6.6]
+## [0.6.7]
 
 ### Changed
 
 - Update NewNodePodUpdater and NewNamespacePodUpdater functions to conditionally check and update kubernetes metadata enrichment of pods
 
 
-[0.6.6]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.6
+[0.6.6]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.7

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -164,12 +164,10 @@ func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore
 
 // OnUpdate handles update events on namespaces.
 func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
-
 	ns, ok := obj.(*Namespace)
 	if !ok {
 		return
 	}
-
 	// n.store.List() returns a snapshot at this point. If a delete is received
 	// from the main watcher, this loop may generate an update event after the
 	// delete is processed, leaving configurations that would never be deleted.
@@ -230,7 +228,6 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
-
 	// n.store.List() returns a snapshot at this point. If a delete is received
 	// from the main watcher, this loop may generate an update event after the
 	// delete is processed, leaving configurations that would never be deleted.

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -167,7 +166,6 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
-	lognode := logp.NewLogger("--------Namespace---------")
 
 	if n.locker != nil {
 		n.locker.Lock()
@@ -177,8 +175,6 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 	// Slice includes the old and new version of caching object that changes in the current update event. slice[0] is the old version and slice[1] the new updated one
 	slice := n.namespacewatcher.Deltaobjects()
 	cachednamespaceold, ok := slice[0].(*Namespace)
-
-	lognode.Infof("-----Slice-------->: %v,  %v ", slice[0], slice[1])
 
 	if ns.Name == cachednamespaceold.Name && ok {
 		labelscheck := checkMetadata(ns.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
@@ -238,6 +234,8 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
+
+	// Slice includes the old and new version of caching object that changes in the current update event. slice[0] is the old version and slice[1] the new updated one
 	slice := n.nodewatcher.Deltaobjects()
 	cachednodeold, ok := slice[0].(*Node)
 

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -183,8 +183,8 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 	cachedNamespace, ok := cachedObject.(*Namespace)
 
 	if ok && ns.Name == cachedNamespace.Name {
-		labelscheck := isEqualMetadata(ns.ObjectMeta.Labels, cachedNamespace.ObjectMeta.Labels)
-		annotationscheck := isEqualMetadata(ns.ObjectMeta.Annotations, cachedNamespace.ObjectMeta.Annotations)
+		labelscheck := reflect.DeepEqual(ns.ObjectMeta.Labels, cachedNamespace.ObjectMeta.Labels)
+		annotationscheck := reflect.DeepEqual(ns.ObjectMeta.Annotations, cachedNamespace.ObjectMeta.Annotations)
 		// Only if there is a difference in Metadata labels or annotations proceed to Pod update
 		if !labelscheck || !annotationscheck {
 			for _, pod := range n.store.List() {
@@ -244,8 +244,8 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 	cachedNode, ok := cachedObject.(*Node)
 
 	if ok && node.Name == cachedNode.Name {
-		labelscheck := isEqualMetadata(node.ObjectMeta.Labels, cachedNode.ObjectMeta.Labels)
-		annotationscheck := isEqualMetadata(node.ObjectMeta.Annotations, cachedNode.ObjectMeta.Annotations)
+		labelscheck := reflect.DeepEqual(node.ObjectMeta.Labels, cachedNode.ObjectMeta.Labels)
+		annotationscheck := reflect.DeepEqual(node.ObjectMeta.Annotations, cachedNode.ObjectMeta.Annotations)
 		// Only if there is a difference in Metadata labels or annotations proceed to Pod update
 		if !labelscheck || !annotationscheck {
 			for _, pod := range n.store.List() {
@@ -265,9 +265,3 @@ func (*nodePodUpdater) OnAdd(interface{}) {}
 // OnDelete handles delete events on namespaces. Nothing to do, if pods are deleted from this
 // namespace they will generate their own delete events.
 func (*nodePodUpdater) OnDelete(interface{}) {}
-
-// isEqualMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a difference
-func isEqualMetadata(newmetadata, oldmetadata map[string]string) bool {
-	check := reflect.DeepEqual(newmetadata, oldmetadata)
-	return check
-}

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -138,9 +138,9 @@ type podUpdaterStore interface {
 	List() []interface{}
 }
 
-// UpdateWatcher is the interface  that an object needs to implement to be
+// OldobjectWatcher is the interface  that an object needs to implement to be
 // able to use Oldobject cache event function from watcher.
-type UpdateWatcher interface {
+type OldobjectWatcher interface {
 	Oldobject() runtime.Object
 }
 
@@ -148,12 +148,12 @@ type UpdateWatcher interface {
 type namespacePodUpdater struct {
 	handler          podUpdaterHandlerFunc
 	store            podUpdaterStore
-	namespacewatcher UpdateWatcher
+	namespacewatcher OldobjectWatcher
 	locker           sync.Locker
 }
 
 // NewNamespacePodUpdater creates a namespacePodUpdater
-func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespacewatcher UpdateWatcher, locker sync.Locker) *namespacePodUpdater {
+func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespacewatcher OldobjectWatcher, locker sync.Locker) *namespacePodUpdater {
 	return &namespacePodUpdater{
 		handler:          handler,
 		store:            store,
@@ -209,12 +209,12 @@ func (*namespacePodUpdater) OnDelete(interface{}) {}
 type nodePodUpdater struct {
 	handler     podUpdaterHandlerFunc
 	store       podUpdaterStore
-	nodewatcher UpdateWatcher
+	nodewatcher OldobjectWatcher
 	locker      sync.Locker
 }
 
 // NewNodePodUpdater creates a nodePodUpdater
-func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodewatcher UpdateWatcher, locker sync.Locker) *nodePodUpdater {
+func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodewatcher OldobjectWatcher, locker sync.Locker) *nodePodUpdater {
 	return &nodePodUpdater{
 		handler:     handler,
 		store:       store,

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -139,7 +139,7 @@ type podUpdaterStore interface {
 }
 
 // NodeStore is the interface that an object needs to implement to be
-// used as a node shared store.
+// used as a namespace shared store.
 type NamespaceStore interface {
 	GetByKey(string) (interface{}, bool, error)
 }
@@ -168,6 +168,7 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
+	// https://pkg.go.dev/k8s.io/client-go/tools/cache#MetaNamespaceKeyFunc Creates key from provided obj
 	key, _ := cache.MetaNamespaceKeyFunc(obj)
 
 	if n.locker != nil {
@@ -240,7 +241,7 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
-
+	// https://pkg.go.dev/k8s.io/client-go/tools/cache#MetaNamespaceKeyFunc Creates key from provided obj
 	key, _ := cache.MetaNamespaceKeyFunc(obj)
 
 	if n.locker != nil {

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -267,7 +267,7 @@ func (*nodePodUpdater) OnAdd(interface{}) {}
 // namespace they will generate their own delete events.
 func (*nodePodUpdater) OnDelete(interface{}) {}
 
-// checkMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a diffrenece
+// checkMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a diffrence
 func checkMetadata(newmetadata, oldmetadata map[string]string) bool {
 	check := reflect.DeepEqual(newmetadata, oldmetadata)
 	return check

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -139,7 +139,7 @@ type podUpdaterStore interface {
 }
 
 // UpdateWatcher is the interface  that an object needs to implement to be
-// able to use DeltaObject cache event function.
+// able to use Oldobject cache event function from watcher.
 type UpdateWatcher interface {
 	Oldobject() runtime.Object
 }

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -138,9 +138,9 @@ type podUpdaterStore interface {
 	List() []interface{}
 }
 
-// OldobjectWatcher is the interface  that an object needs to implement to be
+// OldObjectWatcher is the interface  that an object needs to implement to be
 // able to use Oldobject cache event function from watcher.
-type OldobjectWatcher interface {
+type oldObjectWatcher interface {
 	Oldobject() runtime.Object
 }
 
@@ -148,22 +148,23 @@ type OldobjectWatcher interface {
 type namespacePodUpdater struct {
 	handler          podUpdaterHandlerFunc
 	store            podUpdaterStore
-	namespacewatcher OldobjectWatcher
+	namespaceWatcher oldObjectWatcher
 	locker           sync.Locker
 }
 
 // NewNamespacePodUpdater creates a namespacePodUpdater
-func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespacewatcher OldobjectWatcher, locker sync.Locker) *namespacePodUpdater {
+func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespaceWatcher oldObjectWatcher, locker sync.Locker) *namespacePodUpdater {
 	return &namespacePodUpdater{
 		handler:          handler,
 		store:            store,
-		namespacewatcher: namespacewatcher,
+		namespaceWatcher: namespaceWatcher,
 		locker:           locker,
 	}
 }
 
 // OnUpdate handles update events on namespaces.
 func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
+
 	ns, ok := obj.(*Namespace)
 	if !ok {
 		return
@@ -178,12 +179,12 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	oldobject := n.namespacewatcher.Oldobject()
-	cachednamespaceold, ok := oldobject.(*Namespace)
+	cachedObject := n.namespaceWatcher.Oldobject()
+	cachedNamespace, ok := cachedObject.(*Namespace)
 
-	if ok && ns.Name == cachednamespaceold.Name {
-		labelscheck := isEqualMetadata(ns.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
-		annotationscheck := isEqualMetadata(ns.ObjectMeta.Annotations, cachednamespaceold.ObjectMeta.Annotations)
+	if ok && ns.Name == cachedNamespace.Name {
+		labelscheck := isEqualMetadata(ns.ObjectMeta.Labels, cachedNamespace.ObjectMeta.Labels)
+		annotationscheck := isEqualMetadata(ns.ObjectMeta.Annotations, cachedNamespace.ObjectMeta.Annotations)
 		// Only if there is a difference in Metadata labels or annotations proceed to Pod update
 		if !labelscheck || !annotationscheck {
 			for _, pod := range n.store.List() {
@@ -209,16 +210,16 @@ func (*namespacePodUpdater) OnDelete(interface{}) {}
 type nodePodUpdater struct {
 	handler     podUpdaterHandlerFunc
 	store       podUpdaterStore
-	nodewatcher OldobjectWatcher
+	nodeWatcher oldObjectWatcher
 	locker      sync.Locker
 }
 
 // NewNodePodUpdater creates a nodePodUpdater
-func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodewatcher OldobjectWatcher, locker sync.Locker) *nodePodUpdater {
+func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodeWatcher oldObjectWatcher, locker sync.Locker) *nodePodUpdater {
 	return &nodePodUpdater{
 		handler:     handler,
 		store:       store,
-		nodewatcher: nodewatcher,
+		nodeWatcher: nodeWatcher,
 		locker:      locker,
 	}
 }
@@ -239,13 +240,13 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	oldobject := n.nodewatcher.Oldobject()
-	cachednodeold, ok := oldobject.(*Node)
+	cachedObject := n.nodeWatcher.Oldobject()
+	cachedNode, ok := cachedObject.(*Node)
 
-	if ok && node.Name == cachednodeold.Name {
-		labelscheck := isEqualMetadata(node.ObjectMeta.Labels, cachednodeold.ObjectMeta.Labels)
-		annotationscheck := isEqualMetadata(node.ObjectMeta.Annotations, cachednodeold.ObjectMeta.Annotations)
-		// Only if there is a diffrence in Metadata labels or annotations proceed to Pod update
+	if ok && node.Name == cachedNode.Name {
+		labelscheck := isEqualMetadata(node.ObjectMeta.Labels, cachedNode.ObjectMeta.Labels)
+		annotationscheck := isEqualMetadata(node.ObjectMeta.Annotations, cachedNode.ObjectMeta.Annotations)
+		// Only if there is a difference in Metadata labels or annotations proceed to Pod update
 		if !labelscheck || !annotationscheck {
 			for _, pod := range n.store.List() {
 				pod, ok := pod.(*Pod)
@@ -265,7 +266,7 @@ func (*nodePodUpdater) OnAdd(interface{}) {}
 // namespace they will generate their own delete events.
 func (*nodePodUpdater) OnDelete(interface{}) {}
 
-// isEqualMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a diffrence
+// isEqualMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a difference
 func isEqualMetadata(newmetadata, oldmetadata map[string]string) bool {
 	check := reflect.DeepEqual(newmetadata, oldmetadata)
 	return check

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -20,6 +20,8 @@ package kubernetes
 import (
 	"reflect"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ResourceEventHandler can handle notifications for events that happen to a
@@ -139,7 +141,7 @@ type podUpdaterStore interface {
 // UpdateWatcher is the interface  that an object needs to implement to be
 // able to use DeltaObject cache event function.
 type UpdateWatcher interface {
-	Deltaobjects() Delta
+	Oldobject() runtime.Object
 }
 
 // namespacePodUpdater notifies updates on pods when their namespaces are updated.
@@ -176,11 +178,8 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-
-	// deltaobjects includes the old and new version of caching object that changes in the current update event.
-	// We compare the cached old version of object with the new one that triggers the update
-	deltaobjects := n.namespacewatcher.Deltaobjects()
-	cachednamespaceold, ok := deltaobjects.old.(*Namespace)
+	oldobject := n.namespacewatcher.Oldobject()
+	cachednamespaceold, ok := oldobject.(*Namespace)
 
 	if ok && ns.Name == cachednamespaceold.Name {
 		labelscheck := isEqualMetadata(ns.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
@@ -240,11 +239,8 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-
-	// deltaobjects includes the old and new version of caching object that changes in the current update event.
-	// We compare the cached old version of object with the new one that triggers the update
-	deltaobjects := n.nodewatcher.Deltaobjects()
-	cachednodeold, ok := deltaobjects.old.(*Node)
+	oldobject := n.nodewatcher.Oldobject()
+	cachednodeold, ok := oldobject.(*Node)
 
 	if ok && node.Name == cachednodeold.Name {
 		labelscheck := isEqualMetadata(node.ObjectMeta.Labels, cachednodeold.ObjectMeta.Labels)

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -138,22 +138,22 @@ type podUpdaterStore interface {
 	List() []interface{}
 }
 
-// OldObjectWatcher is the interface  that an object needs to implement to be
-// able to use Oldobject cache event function from watcher.
-type oldObjectWatcher interface {
-	Oldobject() runtime.Object
+// CachedObjectWatcher is the interface  that an object needs to implement to be
+// able to use CachedObject cache event function from watcher.
+type cachedObjectWatcher interface {
+	CachedObject() runtime.Object
 }
 
 // namespacePodUpdater notifies updates on pods when their namespaces are updated.
 type namespacePodUpdater struct {
 	handler          podUpdaterHandlerFunc
 	store            podUpdaterStore
-	namespaceWatcher oldObjectWatcher
+	namespaceWatcher cachedObjectWatcher
 	locker           sync.Locker
 }
 
 // NewNamespacePodUpdater creates a namespacePodUpdater
-func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespaceWatcher oldObjectWatcher, locker sync.Locker) *namespacePodUpdater {
+func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespaceWatcher cachedObjectWatcher, locker sync.Locker) *namespacePodUpdater {
 	return &namespacePodUpdater{
 		handler:          handler,
 		store:            store,
@@ -177,7 +177,7 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	cachedObject := n.namespaceWatcher.Oldobject()
+	cachedObject := n.namespaceWatcher.CachedObject()
 	cachedNamespace, ok := cachedObject.(*Namespace)
 
 	if ok && ns.Name == cachedNamespace.Name {
@@ -208,12 +208,12 @@ func (*namespacePodUpdater) OnDelete(interface{}) {}
 type nodePodUpdater struct {
 	handler     podUpdaterHandlerFunc
 	store       podUpdaterStore
-	nodeWatcher oldObjectWatcher
+	nodeWatcher cachedObjectWatcher
 	locker      sync.Locker
 }
 
 // NewNodePodUpdater creates a nodePodUpdater
-func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodeWatcher oldObjectWatcher, locker sync.Locker) *nodePodUpdater {
+func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodeWatcher cachedObjectWatcher, locker sync.Locker) *nodePodUpdater {
 	return &nodePodUpdater{
 		handler:     handler,
 		store:       store,
@@ -237,7 +237,7 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	cachedObject := n.nodeWatcher.Oldobject()
+	cachedObject := n.nodeWatcher.CachedObject()
 	cachedNode, ok := cachedObject.(*Node)
 
 	if ok && node.Name == cachedNode.Name {

--- a/kubernetes/eventhandler.go
+++ b/kubernetes/eventhandler.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 )
 
 // ResourceEventHandler can handle notifications for events that happen to a
@@ -140,33 +139,25 @@ type podUpdaterStore interface {
 	List() []interface{}
 }
 
-// NodeStore is the interface that an object needs to implement to be
-// used as a namespace shared store.
-type NamespaceStore interface {
-	GetByKey(string) (interface{}, bool, error)
-}
-
-type NamespaceDelta interface {
-	Deltaslice() []runtime.Object
+type UpdateWatcher interface {
+	Deltaobjects() []runtime.Object
 }
 
 // namespacePodUpdater notifies updates on pods when their namespaces are updated.
 type namespacePodUpdater struct {
-	handler        podUpdaterHandlerFunc
-	store          podUpdaterStore
-	namespacestore NamespaceStore
-	namespacedelta NamespaceDelta
-	locker         sync.Locker
+	handler          podUpdaterHandlerFunc
+	store            podUpdaterStore
+	namespacewatcher UpdateWatcher
+	locker           sync.Locker
 }
 
 // NewNamespacePodUpdater creates a namespacePodUpdater
-func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespacestore NamespaceStore, namespacedelta NamespaceDelta, locker sync.Locker) *namespacePodUpdater {
+func NewNamespacePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, namespacewatcher UpdateWatcher, locker sync.Locker) *namespacePodUpdater {
 	return &namespacePodUpdater{
-		handler:        handler,
-		store:          store,
-		namespacestore: namespacestore,
-		namespacedelta: namespacedelta,
-		locker:         locker,
+		handler:          handler,
+		store:            store,
+		namespacewatcher: namespacewatcher,
+		locker:           locker,
 	}
 }
 
@@ -176,46 +167,33 @@ func (n *namespacePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
-	// https://pkg.go.dev/k8s.io/client-go/tools/cache#MetaNamespaceKeyFunc Creates key from provided obj
-	key, _ := cache.MetaNamespaceKeyFunc(obj)
 	lognode := logp.NewLogger("--------Namespace---------")
 
 	if n.locker != nil {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	//Trying to retrieve from the cache. Getbykey returns the object from cache associated with the given object's key
 
-	cachednamespaceobj, exists, err := n.namespacestore.GetByKey(key)
-	slice := n.namespacedelta.Deltaslice()
+	// Slice includes the old and new version of caching object that changes in the current update event. slice[0] is the old version and slice[1] the new updated one
+	slice := n.namespacewatcher.Deltaobjects()
+	cachednamespaceold, ok := slice[0].(*Namespace)
+
 	lognode.Infof("-----Slice-------->: %v,  %v ", slice[0], slice[1])
 
-	labelscheck := true
-	annotationscheck := true
-	if err == nil && exists {
-		cachednamespace, ok := cachednamespaceobj.(*Namespace)
-		cachednamespaceold, ok := slice[0].(*Namespace)
-		if ns.Name == cachednamespace.Name {
-			labelscheck = reflect.DeepEqual(cachednamespace.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
-			annotationscheck = reflect.DeepEqual(cachednamespace.ObjectMeta.Annotations, cachednamespaceold.ObjectMeta.Annotations)
-			if ok {
-				// n.store.List() returns a snapshot at this point. If a delete is received
-				// from the main watcher, this loop may generate an update event after the
-				// delete is processed, leaving configurations that would never be deleted.
-				// Also this loop can miss updates, what could leave outdated configurations.
-				// Avoid these issues by locking the processing of events from the main watcher.
-				for _, pod := range n.store.List() {
-					pod, ok := pod.(*Pod)
-
-					if ok && pod.Namespace == cachednamespace.Name {
-						// Only if an update happend either in Labels or Annotations proceed with Pod updates
-						lognode.Infof("-----Values-------->: %v,  %v ", pod.Namespace, cachednamespace.Name)
-						lognode.Infof("------Checks------->: %v,  %v ", labelscheck, annotationscheck)
-						lognode.Infof("------Labels------->: %v,  %v ", cachednamespace.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
-						if !labelscheck || !annotationscheck {
-							n.handler(pod)
-						}
-					}
+	if ns.Name == cachednamespaceold.Name && ok {
+		labelscheck := checkMetadata(ns.ObjectMeta.Labels, cachednamespaceold.ObjectMeta.Labels)
+		annotationscheck := checkMetadata(ns.ObjectMeta.Annotations, cachednamespaceold.ObjectMeta.Annotations)
+		// Only if there is a diffrence in Metadata labels or annotations proceed to Pod update
+		if !labelscheck || !annotationscheck {
+			// n.store.List() returns a snapshot at this point. If a delete is received
+			// from the main watcher, this loop may generate an update event after the
+			// delete is processed, leaving configurations that would never be deleted.
+			// Also this loop can miss updates, what could leave outdated configurations.
+			// Avoid these issues by locking the processing of events from the main watcher.
+			for _, pod := range n.store.List() {
+				pod, ok := pod.(*Pod)
+				if ok && pod.Namespace == ns.Name {
+					n.handler(pod)
 				}
 			}
 		}
@@ -233,25 +211,19 @@ func (*namespacePodUpdater) OnDelete(interface{}) {}
 
 // nodePodUpdater notifies updates on pods when their nodes are updated.
 type nodePodUpdater struct {
-	handler   podUpdaterHandlerFunc
-	store     podUpdaterStore
-	nodestore NodeStore
-	locker    sync.Locker
-}
-
-// NodeStore is the interface that an object needs to implement to be
-// used as a node shared store.
-type NodeStore interface {
-	GetByKey(string) (interface{}, bool, error)
+	handler     podUpdaterHandlerFunc
+	store       podUpdaterStore
+	nodewatcher UpdateWatcher
+	locker      sync.Locker
 }
 
 // NewNodePodUpdater creates a nodePodUpdater
-func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodestore NodeStore, locker sync.Locker) *nodePodUpdater {
+func NewNodePodUpdater(handler podUpdaterHandlerFunc, store podUpdaterStore, nodewatcher UpdateWatcher, locker sync.Locker) *nodePodUpdater {
 	return &nodePodUpdater{
-		handler:   handler,
-		store:     store,
-		nodestore: nodestore,
-		locker:    locker,
+		handler:     handler,
+		store:       store,
+		nodewatcher: nodewatcher,
+		locker:      locker,
 	}
 }
 
@@ -261,38 +233,29 @@ func (n *nodePodUpdater) OnUpdate(obj interface{}) {
 	if !ok {
 		return
 	}
-	// https://pkg.go.dev/k8s.io/client-go/tools/cache#MetaNamespaceKeyFunc Creates key from provided obj
-	key, _ := cache.MetaNamespaceKeyFunc(obj)
-	lognode := logp.NewLogger("--------Node---------")
 
 	if n.locker != nil {
 		n.locker.Lock()
 		defer n.locker.Unlock()
 	}
-	//Trying to retrieve from the cache. Getbykey returns the object from cache associated with the given object's key
-	cachednodeobj, exists, err := n.nodestore.GetByKey(key)
+	slice := n.nodewatcher.Deltaobjects()
+	cachednodeold, ok := slice[0].(*Node)
 
-	labelscheck := true
-	annotationscheck := true
-	if err == nil && exists {
-		cachednode, ok := cachednodeobj.(*Node)
-		lognode.Infof("Node: %v .", cachednode.Labels)
-		if ok {
-			labelscheck = reflect.DeepEqual(node.ObjectMeta.Labels, cachednode.Labels)
-			annotationscheck = reflect.DeepEqual(node.ObjectMeta.Annotations, cachednode.Annotations)
-		}
-	}
-	// Only if an update happend either in Labels or Annotations proceed with Pod updates
-	if !labelscheck || !annotationscheck {
-		// n.store.List() returns a snapshot at this point. If a delete is received
-		// from the main watcher, this loop may generate an update event after the
-		// delete is processed, leaving configurations that would never be deleted.
-		// Also this loop can miss updates, what could leave outdated configurations.
-		// Avoid these issues by locking the processing of events from the main watcher.
-		for _, pod := range n.store.List() {
-			pod, ok := pod.(*Pod)
-			if ok && pod.Spec.NodeName == node.Name {
-				n.handler(pod)
+	if node.Name == cachednodeold.Name && ok {
+		labelscheck := checkMetadata(node.ObjectMeta.Labels, cachednodeold.ObjectMeta.Labels)
+		annotationscheck := checkMetadata(node.ObjectMeta.Annotations, cachednodeold.ObjectMeta.Annotations)
+		// Only if there is a diffrence in Metadata labels or annotations proceed to Pod update
+		if !labelscheck || !annotationscheck {
+			// n.store.List() returns a snapshot at this point. If a delete is received
+			// from the main watcher, this loop may generate an update event after the
+			// delete is processed, leaving configurations that would never be deleted.
+			// Also this loop can miss updates, what could leave outdated configurations.
+			// Avoid these issues by locking the processing of events from the main watcher.
+			for _, pod := range n.store.List() {
+				pod, ok := pod.(*Pod)
+				if ok && pod.Spec.NodeName == node.Name {
+					n.handler(pod)
+				}
 			}
 		}
 	}
@@ -305,3 +268,9 @@ func (*nodePodUpdater) OnAdd(interface{}) {}
 // OnDelete handles delete events on namespaces. Nothing to do, if pods are deleted from this
 // namespace they will generate their own delete events.
 func (*nodePodUpdater) OnDelete(interface{}) {}
+
+// checkMetadata receives labels or annotations maps and checks their equality. Returns True if equal, False if there is a diffrenece
+func checkMetadata(newmetadata, oldmetadata map[string]string) bool {
+	check := reflect.DeepEqual(newmetadata, oldmetadata)
+	return check
+}

--- a/kubernetes/metadata/pod.go
+++ b/kubernetes/metadata/pod.go
@@ -74,6 +74,7 @@ func (p *pod) Generate(obj kubernetes.Resource, opts ...FieldOptions) mapstr.M {
 		"kubernetes": p.GenerateK8s(obj, opts...),
 	}
 	meta.DeepUpdate(ecsFields)
+
 	return meta
 }
 

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -191,7 +191,7 @@ func (w *watcher) Client() kubernetes.Interface {
 	return w.client
 }
 
-// Oldbject returns the old object in cache during the last updated event
+// CachedObject returns the old object in cache during the last updated event
 func (w *watcher) CachedObject() runtime.Object {
 	return w.cachedObject
 }

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -162,7 +162,7 @@ func NewNamedWatcher(name string, client kubernetes.Interface, resource Resource
 				// state should just be deduped by autodiscover and not stop/started periodically as would be the case with an update.
 				w.enqueue(n, add)
 			}
-			w.oldobjectreturn(o)
+			w.cacheObject(o)
 
 		},
 	})
@@ -229,10 +229,11 @@ func (w *watcher) enqueue(obj interface{}, state string) {
 	w.queue.Add(&item{key, obj, state})
 }
 
-// oldobjectreturn returns the old version of cache objects before change on update events
-func (w *watcher) oldobjectreturn(o interface{}) {
+// cacheObject updates watcher with the old version of cache objects before change during update events
+func (w *watcher) cacheObject(o interface{}) {
 	if old, ok := o.(runtime.Object); !ok {
-		utilruntime.HandleError(fmt.Errorf("expected object in cache  got %#v", o))
+		w.logger.Debugf("Old Object was not retrieved from cache: %v", o)
+		w.oldobject = nil
 	} else {
 		w.oldobject = old
 	}

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -231,7 +231,11 @@ func (w *watcher) enqueue(obj interface{}, state string) {
 
 // oldobjectreturn returns the old version of cache objects before change on update events
 func (w *watcher) oldobjectreturn(o interface{}) {
-	w.oldobject = o.(runtime.Object)
+	if old, ok := o.(runtime.Object); !ok {
+		utilruntime.HandleError(fmt.Errorf("expected object in cache  got %#v", o))
+	} else {
+		w.oldobject = old
+	}
 }
 
 // process gets the top of the work queue and processes the object that is received.

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -185,7 +185,7 @@ func (w *watcher) Client() kubernetes.Interface {
 	return w.client
 }
 
-// Client returns the kubernetes client object used by the watcher
+// Deltaobjects returns the slice of objects that change during the last updated event
 func (w *watcher) Deltaobjects() []runtime.Object {
 	return w.delta
 }

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -20,8 +20,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -166,11 +164,12 @@ func NewNamedWatcher(name string, client kubernetes.Interface, resource Resource
 			}
 
 			//We check the type of resource and only if it is namespace or node return the cacheObject
-			stringresource := reflect.TypeOf(resource).String()
-			if strings.Contains(strings.ToLower(stringresource), "namespace") || strings.Contains(strings.ToLower(stringresource), "node") {
+			switch resource.(type) {
+			case *Namespace:
+				w.cacheObject(o)
+			case *Node:
 				w.cacheObject(o)
 			}
-
 		},
 	})
 

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -20,6 +20,8 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -162,7 +164,12 @@ func NewNamedWatcher(name string, client kubernetes.Interface, resource Resource
 				// state should just be deduped by autodiscover and not stop/started periodically as would be the case with an update.
 				w.enqueue(n, add)
 			}
-			w.cacheObject(o)
+
+			//We check the type of resource and only if it is namespace or node return the cacheObject
+			stringresource := reflect.TypeOf(resource).String()
+			if strings.Contains(strings.ToLower(stringresource), "namespace") || strings.Contains(strings.ToLower(stringresource), "node") {
+				w.cacheObject(o)
+			}
 
 		},
 	})

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -60,8 +60,8 @@ type Watcher interface {
 	// Client returns the kubernetes client object used by the watcher
 	Client() kubernetes.Interface
 
-	// Delta returns the slice of objects changed by the last updated event
-	Deltaslice() []runtime.Object
+	// Deltaobjects returns the slice of objects that change during the last updated event
+	Deltaobjects() []runtime.Object
 }
 
 // WatchOptions controls watch behaviors
@@ -162,7 +162,7 @@ func NewNamedWatcher(name string, client kubernetes.Interface, resource Resource
 				// state should just be deduped by autodiscover and not stop/started periodically as would be the case with an update.
 				w.enqueue(n, add)
 			}
-			w.deltaslice(o, n)
+			w.deltaobjects(o, n)
 
 		},
 	})
@@ -186,7 +186,7 @@ func (w *watcher) Client() kubernetes.Interface {
 }
 
 // Client returns the kubernetes client object used by the watcher
-func (w *watcher) Deltaslice() []runtime.Object {
+func (w *watcher) Deltaobjects() []runtime.Object {
 	return w.delta
 }
 
@@ -229,7 +229,10 @@ func (w *watcher) enqueue(obj interface{}, state string) {
 	w.queue.Add(&item{key, obj, state})
 }
 
-func (w *watcher) deltaslice(o interface{}, n interface{}) {
+// deltaobjects creates a slice with the old and the new version of cache objects that are ready to chane on update events
+// returns a delta struct to the watcher. w.delta[0] is the old version and w.delta[1] the new updated one
+func (w *watcher) deltaobjects(o interface{}, n interface{}) {
+	//w.delta[:0] initialises always the delta struct before new assignement
 	w.delta = w.delta[:0]
 	w.delta = append(w.delta, o.(runtime.Object))
 	w.delta = append(w.delta, n.(runtime.Object))


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- WHAT: Update the PodUpdater fucntion with additonal checks before actaully triggering Pod watcher restarts
- WHY:  There where node and namespace events that dont always inlcude Metadata changes. We want only update events that change labels and annotations of node and namespace to trigger pod updates. This leads to bettwr management of watchers


## How to test this PR locally

See info https://github.com/elastic/beats/issues/37338

## Related issues

- Relates https://github.com/elastic/beats/issues/37338
- Relates https://github.com/elastic/beats/pull/37431