### PR TITLE
Fix default resource metadata config

### DIFF
--- a/kubernetes/metadata/config.go
+++ b/kubernetes/metadata/config.go
@@ -59,10 +59,11 @@ func (c *Config) Unmarshal(cfg *config.C) error {
 func GetDefaultResourceMetadataConfig() *AddResourceMetadataConfig {
 	metaConfig := Config{}
 	metaConfig.InitDefaults()
-	metaCfg, _ := config.NewConfigFrom(&metaConfig)
+	nodeCfg, _ := config.NewConfigFrom(metaConfig)
+	nsCfg, _ := config.NewConfigFrom(metaConfig)
 	return &AddResourceMetadataConfig{
-		Node:       metaCfg,
-		Namespace:  metaCfg,
+		Node:       nodeCfg,
+		Namespace:  nsCfg,
 		Deployment: false,
 		CronJob:    false,
 	}

--- a/kubernetes/metadata/pod_test.go
+++ b/kubernetes/metadata/pod_test.go
@@ -430,6 +430,7 @@ func TestPod_Generate(t *testing.T) {
 		"annotations.dedot":   false,
 	})
 	assert.NoError(t, err)
+	assert.NotEqual(t, *addResourceMetadata.Namespace, *addResourceMetadata.Node)
 
 	replicaSets := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	err = replicaSets.Add(rs)


### PR DESCRIPTION
fix default metadata config: ensure that AddResourceMetadataConfig.Node and AddResourceMetadataConfig.Namespace are different objects

Relates https://github.com/elastic/elastic-agent/issues/3636