### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/add-issues-to-ingest-board.yml
+++ b/.github/workflows/add-issues-to-ingest-board.yml
@@ -13,6 +13,9 @@ env:
   AREA_FIELD_ID: 'PVTSSF_lADOAGc3Zs4AEzn4zgEgZSo'
   ELASTIC_AGENT_OPTION_ID: 'c1e1a30a'
 
+permissions:
+  contents: read
+
 jobs:
   add_to_ingest_project:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
