### PR TITLE
Introduce checks for not supported annotations for Hints based autodiscover of Elastic Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 [0.6.7]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.2...v0.6.7
+
+## [0.6.9]
+
+### Changed
+
+- Update GenerateHints function to check supported list of hints
+
+
+[0.6.9]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.6.8...v0.6.9

--- a/utils/hints.go
+++ b/utils/hints.go
@@ -202,9 +202,9 @@ func IsDisabled(hints mapstr.M, key string) bool {
 }
 
 // GenerateHints parses annotations based on a prefix and sets up hints that can be picked up by individual Beats.
-func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedHints []string) (mapstr.M, error) {
+func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedHints []string) (mapstr.M, []string) {
 	hints := mapstr.M{}
-	returnerror := error(nil)
+	var incorrecthints []string
 	if rawEntries, err := annotations.GetValue(prefix); err == nil {
 		if entries, ok := rawEntries.(mapstr.M); ok {
 			for key, rawValue := range entries {
@@ -261,20 +261,14 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 						}
 					}
 				}
-
 				if !found {
-					returnerror = fmt.Errorf("provided hint :%v is not in the supported list", parts[1])
-				} //End of check
-
+					incorrecthints = append(incorrecthints, key)
+				}
 			}
 		}
 	}
 
-	if returnerror == nil {
-		return hints, nil
-	}
-
-	return hints, returnerror
+	return hints, incorrecthints
 }
 
 // GetHintsAsList gets a set of hints and tries to convert them into a list of hints

--- a/utils/hints.go
+++ b/utils/hints.go
@@ -215,7 +215,7 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 				parts := strings.Split(key, "/")
 				if len(parts) == 2 {
 					hintKey := fmt.Sprintf("%s.%s", parts[0], parts[1])
-					//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
+					//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that have prefix co.elastic
 					found = checkSupportedHints(parts[1], allSupportedHints)
 
 					// Insert only if there is no entry already. container level annotations take
@@ -239,7 +239,7 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 						if strings.HasPrefix(hintKey, container) {
 							// Split the key to get part[1] to be the hint
 							parts := strings.Split(hintKey, "/")
-							//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
+							//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that have prefix co.elastic
 							found = checkSupportedHints(parts[1], allSupportedHints)
 							if len(parts) == 2 {
 								// key will be the hint type

--- a/utils/hints.go
+++ b/utils/hints.go
@@ -208,22 +208,19 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 	if rawEntries, err := annotations.GetValue(prefix); err == nil {
 		if entries, ok := rawEntries.(mapstr.M); ok {
 			for key, rawValue := range entries {
+				found := false
 				// If there are top level hints like co.elastic.logs/ then just add the values after the /
 				// Only consider namespaced annotations
 				parts := strings.Split(key, "/")
 				if len(parts) == 2 {
 					hintKey := fmt.Sprintf("%s.%s", parts[0], parts[1])
 					//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
-					found := false
 					for _, checksupported := range allSupportedHints {
 						if parts[1] == checksupported {
 							found = true
 							break
 						}
 					}
-					if !found {
-						returnerror = fmt.Errorf("provided hint :%v is not in the supported list", parts[1])
-					} //End of check
 
 					// Insert only if there is no entry already. container level annotations take
 					// higher priority.
@@ -246,6 +243,13 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 						if strings.HasPrefix(hintKey, container) {
 							// Split the key to get part[1] to be the hint
 							parts := strings.Split(hintKey, "/")
+							//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
+							for _, checksupported := range allSupportedHints {
+								if parts[1] == checksupported {
+									found = true
+									break
+								}
+							}
 							if len(parts) == 2 {
 								// key will be the hint type
 								hintKey := fmt.Sprintf("%s.%s", key, parts[1])
@@ -257,6 +261,11 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 						}
 					}
 				}
+
+				if !found {
+					returnerror = fmt.Errorf("provided hint :%v is not in the supported list", parts[1])
+				} //End of check
+
 			}
 		}
 	}

--- a/utils/hints.go
+++ b/utils/hints.go
@@ -205,22 +205,18 @@ func IsDisabled(hints mapstr.M, key string) bool {
 func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedHints []string) (mapstr.M, []string) {
 	hints := mapstr.M{}
 	var incorrecthints []string
+	found := false
 	if rawEntries, err := annotations.GetValue(prefix); err == nil {
 		if entries, ok := rawEntries.(mapstr.M); ok {
 			for key, rawValue := range entries {
-				found := false
+
 				// If there are top level hints like co.elastic.logs/ then just add the values after the /
 				// Only consider namespaced annotations
 				parts := strings.Split(key, "/")
 				if len(parts) == 2 {
 					hintKey := fmt.Sprintf("%s.%s", parts[0], parts[1])
 					//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
-					for _, checksupported := range allSupportedHints {
-						if parts[1] == checksupported {
-							found = true
-							break
-						}
-					}
+					found = checkSupportedHints(parts[1], allSupportedHints)
 
 					// Insert only if there is no entry already. container level annotations take
 					// higher priority.
@@ -244,12 +240,7 @@ func GenerateHints(annotations mapstr.M, container, prefix string, allSupportedH
 							// Split the key to get part[1] to be the hint
 							parts := strings.Split(hintKey, "/")
 							//We check whether the provided annotation follows the supported format and vocabulary. The check happens for annotations that start with co.elastic.hints
-							for _, checksupported := range allSupportedHints {
-								if parts[1] == checksupported {
-									found = true
-									break
-								}
-							}
+							found = checkSupportedHints(parts[1], allSupportedHints)
 							if len(parts) == 2 {
 								// key will be the hint type
 								hintKey := fmt.Sprintf("%s.%s", key, parts[1])
@@ -308,4 +299,16 @@ func GetHintsAsList(hints mapstr.M, key string) []mapstr.M {
 		configs = append(configs, defaultMap)
 	}
 	return configs
+}
+
+// checkSupportedHints gets a specific hint annotation and compares it with the supported list of hints
+func checkSupportedHints(actualannotation string, allSupportedHints []string) bool {
+	found := false
+	for _, checksupported := range allSupportedHints {
+		if actualannotation == checksupported {
+			found = true
+			break
+		}
+	}
+	return found
 }

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -69,7 +69,7 @@ func TestGenerateHints(t *testing.T) {
 		name                   string
 		annotations            map[string]string
 		result                 mapstr.M
-		expectedIncorrectHints int // We set the number of hints that will be marked as incorrect and wont part of the acceptable supported list
+		expectedIncorrectHints int // We set the number of hints that will be marked as incorrect and wont be included in the acceptable supported list
 	}{
 		//Empty annotations should return empty hints
 		{

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -50,6 +50,21 @@ func TestGetProcessors(t *testing.T) {
 }
 
 func TestGenerateHints(t *testing.T) {
+	const (
+		integration = "package"
+		datastreams = "data_streams"
+		host        = "host"
+		period      = "period"
+		timeout     = "timeout"
+		metricspath = "metrics_path"
+		username    = "username"
+		password    = "password"
+		stream      = "stream" // this is the container stream: stdout/stderr
+		processors  = "processors"
+	)
+
+	var allSupportedHints = []string{"enabled", integration, datastreams, host, period, timeout, metricspath, username, password, stream, processors}
+
 	tests := []struct {
 		annotations map[string]string
 		result      mapstr.M
@@ -219,7 +234,8 @@ func TestGenerateHints(t *testing.T) {
 				continue
 			}
 		}
-		assert.Equal(t, test.result, GenerateHints(annMap, "foobar", "co.elastic"))
+		generateHints, _ := GenerateHints(annMap, "foobar", "co.elastic", allSupportedHints)
+		assert.Equal(t, test.result, generateHints)
 	}
 }
 func TestGetHintsAsList(t *testing.T) {

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -70,7 +70,7 @@ func TestGenerateHints(t *testing.T) {
 		annotations map[string]string
 		result      mapstr.M
 	}{
-		Empty annotations should return empty hints
+		//Empty annotations should return empty hints
 		{
 			name:        "test0",
 			annotations: map[string]string{},
@@ -243,12 +243,12 @@ func TestGenerateHints(t *testing.T) {
 				continue
 			}
 		}
-		generateHints, incorrecthints := GenerateHints(annMap, "foobar", "co.elastic", allSupportedHints)
+		generateHints, incorrectHints := GenerateHints(annMap, "foobar", "co.elastic", allSupportedHints)
 		//Only in test2 we have added co.elastic.hints.steam annotation with a typo error
 		if test.name == "test2" {
-			assert.Equal(t, 1, len(incorrecthints)) // We validate how many incorrect hints are provided in test1.
+			assert.Equal(t, 1, len(incorrectHints)) // We validate how many incorrect hints are provided in test1.
 		} else {
-			assert.Equal(t, 0, len(incorrecthints)) // We validate how many incorrect hints are provided in rest of tests
+			assert.Equal(t, 0, len(incorrectHints)) // We validate how many incorrect hints are provided in rest of tests
 		}
 		assert.Equal(t, test.result, generateHints)
 	}

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -72,7 +72,7 @@ func TestGenerateHints(t *testing.T) {
 	}{
 		//Empty annotations should return empty hints
 		{
-			name:        "test0",
+			name:        "Empty_Annotations",
 			annotations: map[string]string{},
 			result:      mapstr.M{},
 		},
@@ -85,7 +85,7 @@ func TestGenerateHints(t *testing.T) {
 		// not.to.include must not be part of hints
 		// period is annotated at both container and pod level. Container level value must be in hints
 		{
-			name: "test1",
+			name: "Logs_multiline_and_metrics",
 			annotations: map[string]string{
 				"co.elastic.logs/multiline.pattern":    "^test",
 				"co.elastic.logs/json.keys_under_root": "true",
@@ -116,7 +116,7 @@ func TestGenerateHints(t *testing.T) {
 		// not.to.include must not be part of hints
 		// metrics/metrics_path must be found in hints.metrics
 		{
-			name: "test2",
+			name: "Logs_multiline_and_metrics_with_metrics_path",
 			annotations: map[string]string{
 				"co.elastic.logs/multiline.pattern": "^test",
 				"co.elastic.metrics/module":         "prometheus",
@@ -146,13 +146,12 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		// Scenarios being tested:
-		// have co.elastic.logs/disable set to false.
 		// logs/multiline.pattern must be a nested mapstr.M under hints.logs
 		// metrics/module must be found in hints.metrics
 		// not.to.include must not be part of hints
 		// period is annotated at both container and pod level. Container level value must be in hints
 		{
-			name: "test3",
+			name: "Logs_multiline_and_metrics",
 			annotations: map[string]string{
 				"co.elastic.logs/multiline.pattern": "^test",
 				"co.elastic.metrics/module":         "prometheus",
@@ -180,7 +179,7 @@ func TestGenerateHints(t *testing.T) {
 		// not.to.include must not be part of hints
 		// period is annotated at both container and pod level. Container level value must be in hints
 		{
-			name: "test4",
+			name: "Logs_disabled_false_and_metrics",
 			annotations: map[string]string{
 				"co.elastic.logs/disable":           "false",
 				"co.elastic.logs/multiline.pattern": "^test",
@@ -210,7 +209,7 @@ func TestGenerateHints(t *testing.T) {
 		// not.to.include must not be part of hints
 		// period is annotated at both container and pod level. Container level value must be in hints
 		{
-			name: "test5",
+			name: "Logs_disabled_true_and_metrics",
 			annotations: map[string]string{
 				"co.elastic.logs/disable":           "true",
 				"co.elastic.logs/multiline.pattern": "^test",
@@ -244,8 +243,8 @@ func TestGenerateHints(t *testing.T) {
 			}
 		}
 		generateHints, incorrectHints := GenerateHints(annMap, "foobar", "co.elastic", allSupportedHints)
-		//Only in test2 we have added co.elastic.hints.steam annotation with a typo error
-		if test.name == "test2" {
+		//Only in Logs_multiline_and_metrics_with_metrics_path we have added co.elastic.hints.steam annotation with a typo error
+		if test.name == "Logs_multiline_and_metrics_with_metrics_path" {
 			assert.Equal(t, 1, len(incorrectHints)) // We validate how many incorrect hints are provided in test1.
 		} else {
 			assert.Equal(t, 0, len(incorrectHints)) // We validate how many incorrect hints are provided in rest of tests

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -50,20 +50,8 @@ func TestGetProcessors(t *testing.T) {
 }
 
 func TestGenerateHints(t *testing.T) {
-	const (
-		integration = "package"
-		datastreams = "data_streams"
-		host        = "host"
-		period      = "period"
-		timeout     = "timeout"
-		metricspath = "metrics_path"
-		username    = "username"
-		password    = "password"
-		stream      = "stream" // this is the container stream: stdout/stderr
-		processors  = "processors"
-	)
 
-	var allSupportedHints = []string{"enabled", "module", integration, datastreams, host, period, timeout, metricspath, username, password, stream, processors, "multiline", "json", "disable"}
+	var allSupportedHints = []string{"enabled", "module", "integration", "datas_treams", "host", "period", "timeout", "metrics_path", "username", "password", "stream", "processors", "multiline", "json", "disable"}
 
 	tests := []struct {
 		name                   string

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -70,20 +70,20 @@ func TestGenerateHints(t *testing.T) {
 		annotations map[string]string
 		result      mapstr.M
 	}{
-		// Empty annotations should return empty hints
-		// {
-		// 	name:        "test0",
-		// 	annotations: map[string]string{},
-		// 	result:      mapstr.M{},
-		// },
+		Empty annotations should return empty hints
+		{
+			name:        "test0",
+			annotations: map[string]string{},
+			result:      mapstr.M{},
+		},
 
-		// // Scenarios being tested:
-		// // logs/multiline.pattern must be a nested mapstr.M under hints.logs
-		// // logs/processors.add_fields must be nested mapstr.M under hints.logs
-		// // logs/json.keys_under_root must be a nested mapstr.M under hints.logs
-		// // metrics/module must be found in hints.metrics
-		// // not.to.include must not be part of hints
-		// // period is annotated at both container and pod level. Container level value must be in hints
+		// Scenarios being tested:
+		// logs/multiline.pattern must be a nested mapstr.M under hints.logs
+		// logs/processors.add_fields must be nested mapstr.M under hints.logs
+		// logs/json.keys_under_root must be a nested mapstr.M under hints.logs
+		// metrics/module must be found in hints.metrics
+		// not.to.include must not be part of hints
+		// period is annotated at both container and pod level. Container level value must be in hints
 		{
 			name: "test1",
 			annotations: map[string]string{
@@ -244,10 +244,8 @@ func TestGenerateHints(t *testing.T) {
 			}
 		}
 		generateHints, incorrecthints := GenerateHints(annMap, "foobar", "co.elastic", allSupportedHints)
-		//Only in test1 we have added co.elastic.hints.steam annotation with a typo error
+		//Only in test2 we have added co.elastic.hints.steam annotation with a typo error
 		if test.name == "test2" {
-			t.Log(annMap)
-			t.Log(incorrecthints)
 			assert.Equal(t, 1, len(incorrecthints)) // We validate how many incorrect hints are provided in test1.
 		} else {
 			assert.Equal(t, 0, len(incorrecthints)) // We validate how many incorrect hints are provided in rest of tests

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -63,7 +63,7 @@ func TestGenerateHints(t *testing.T) {
 		processors  = "processors"
 	)
 
-	var allSupportedHints = []string{"enabled", integration, datastreams, host, period, timeout, metricspath, username, password, stream, processors}
+	var allSupportedHints = []string{"enabled", "module", integration, datastreams, host, period, timeout, metricspath, username, password, stream, processors}
 
 	tests := []struct {
 		annotations map[string]string
@@ -114,15 +114,15 @@ func TestGenerateHints(t *testing.T) {
 		// metrics/metrics_path must be found in hints.metrics
 		{
 			annotations: map[string]string{
-				"co.elastic.logs/multiline.pattern": "^test",
-				"co.elastic.metrics/module":         "prometheus",
-				"co.elastic.metrics/period":         "10s",
-				"co.elastic.metrics/metrics_path":   "/metrics/prometheus",
-				"co.elastic.metrics/username":       "user",
-				"co.elastic.metrics/password":       "pass",
-				"co.elastic.metrics.foobar/period":  "15s",
-				"co.elastic.metrics.foobar1/period": "15s",
-				"not.to.include":                    "true",
+				"co.elastic.logs/multiline.pattern":  "^test",
+				"co.elastic.metrics/module":          "prometheus",
+				"co.elastic.metrics/period":          "10s",
+				"co.elastic.metrics/metrics_path":    "/metrics/prometheus",
+				"co.elastic.metrics/username":        "user",
+				"co.elastic.metrics/password":        "pass",
+				"co.elastic.metrics.foobar/period":   "15s",
+				"co.elastic.metrics.foobar1/periods": "15s",
+				"not.to.include":                     "true",
 			},
 			result: mapstr.M{
 				"logs": mapstr.M{


### PR DESCRIPTION
This PR relates to https://github.com/elastic/elastic-agent/issues/3064 and 
https://github.com/elastic/elastic-agent/pull/4360

It provides the checks for the supported hints. 
This PR needs to be merged before the https://github.com/elastic/elastic-agent/pull/4360