### PR TITLE
Align CI go version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 
 env:
   SETUP_GVM_VERSION: 'v0.5.0'
-  GO_VERSION_CHOCO: "1.21.12"
+  GO_VERSION_CHOCO: "1.21.7"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 
 env:
   SETUP_GVM_VERSION: 'v0.5.0'
-  GO_VERSION_CHOCO: "1.20.5"
+  GO_VERSION_CHOCO: "1.21.12"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 
 env:
   SETUP_GVM_VERSION: 'v0.5.0'
-  GO_VERSION_CHOCO: "1.21.7"
+  GO_VERSION_CHOCO: "1.22.5"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
 


### PR DESCRIPTION
trying to align the go version used in CI with the one we used for this project - https://github.com/elastic/elastic-agent-autodiscover/blob/main/.go-version