### PR TITLE
Allow ReplicaSet and Job metadata generators to use partial meta objects

### DIFF
--- a/kubernetes/metadata/job.go
+++ b/kubernetes/metadata/job.go
@@ -18,6 +18,7 @@
 package metadata
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -65,7 +66,7 @@ func (jb *job) GenerateECS(obj kubernetes.Resource) mapstr.M {
 
 // GenerateK8s generates job metadata from a resource object
 func (jb *job) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) mapstr.M {
-	_, ok := obj.(*kubernetes.Job)
+	_, ok := obj.(metav1.Object)
 	if !ok {
 		return nil
 	}
@@ -81,12 +82,12 @@ func (jb *job) GenerateFromName(name string, opts ...FieldOptions) mapstr.M {
 	}
 
 	if obj, ok, _ := jb.store.GetByKey(name); ok {
-		jobObj, ok := obj.(*kubernetes.Job)
+		res, ok := obj.(kubernetes.Resource)
 		if !ok {
 			return nil
 		}
 
-		return jb.GenerateK8s(jobObj, opts...)
+		return jb.GenerateK8s(res, opts...)
 	}
 
 	return nil

--- a/kubernetes/metadata/replicaset.go
+++ b/kubernetes/metadata/replicaset.go
@@ -18,6 +18,7 @@
 package metadata
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -67,7 +68,7 @@ func (rs *replicaset) GenerateECS(obj kubernetes.Resource) mapstr.M {
 
 // GenerateK8s generates replicaset metadata from a resource object
 func (rs *replicaset) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) mapstr.M {
-	_, ok := obj.(*kubernetes.ReplicaSet)
+	_, ok := obj.(metav1.Object)
 	if !ok {
 		return nil
 	}
@@ -83,12 +84,12 @@ func (rs *replicaset) GenerateFromName(name string, opts ...FieldOptions) mapstr
 	}
 
 	if obj, ok, _ := rs.store.GetByKey(name); ok {
-		replicaSet, ok := obj.(*kubernetes.ReplicaSet)
+		res, ok := obj.(kubernetes.Resource)
 		if !ok {
 			return nil
 		}
 
-		return rs.GenerateK8s(replicaSet, opts...)
+		return rs.GenerateK8s(res, opts...)
 	}
 
 	return nil

--- a/kubernetes/metadata/resource.go
+++ b/kubernetes/metadata/resource.go
@@ -21,10 +21,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 	"k8s.io/apimachinery/pkg/api/meta"
+
 	k8s "k8s.io/client-go/kubernetes"
 
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 	"github.com/elastic/elastic-agent-autodiscover/utils"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -85,7 +86,7 @@ func (r *Resource) Generate(kind string, obj kubernetes.Resource, opts ...FieldO
 }
 
 // GenerateECS generates ECS metadata from a resource object
-func (r *Resource) GenerateECS(obj kubernetes.Resource) mapstr.M {
+func (r *Resource) GenerateECS(_ kubernetes.Resource) mapstr.M {
 	ecsMeta := mapstr.M{}
 	if r.clusterInfo.URL != "" {
 		_, _ = ecsMeta.Put("orchestrator.cluster.url", r.clusterInfo.URL)


### PR DESCRIPTION
We only use metadata from Jobs and ReplicaSets, but require that full resources are supplied. This change relaxes this requirement, allowing PartialObjectMetadata resources to be used. This allows callers to use metadata informers and avoid having to receive and deserialize non-metadata updates from the API Server.

See https://github.com/elastic/elastic-agent/pull/5580 for an example of how this could be used. I'm planning to add the metadata informer from that PR to this library as well. Together, these will allow us to greatly reduce memory used for processing and storing ReplicaSets and Jobs in beats and elastic-agent.

This is will help https://github.com/elastic/elastic-agent/pull/5580 and https://github.com/elastic/elastic-agent/issues/4729 specifically, and https://github.com/elastic/elastic-agent/issues/3801 in general.
