### PR TITLE
Add metadata watcher and informer

### DIFF
--- a/kubernetes/metadata/replicaset.go
+++ b/kubernetes/metadata/replicaset.go
@@ -19,7 +19,6 @@ package metadata
 
 import (
 	"fmt"
-	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,6 +123,6 @@ func RemoveUnnecessaryReplicaSetData(obj interface{}) (interface{}, error) {
 		}
 		return transformed, nil
 	default:
-		return nil, fmt.Errorf("obj of type %v neither a ReplicaSet nor a PartialObjectMetadata", reflect.TypeOf(obj))
+		return nil, fmt.Errorf("obj of type %T neither a ReplicaSet nor a PartialObjectMetadata", obj)
 	}
 }

--- a/kubernetes/metadata/replicaset_test.go
+++ b/kubernetes/metadata/replicaset_test.go
@@ -120,7 +120,7 @@ func TestReplicaset_Generate(t *testing.T) {
 	}
 }
 
-func TestReplicast_GenerateFromName(t *testing.T) {
+func TestReplicaset_GenerateFromName(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
 	boolean := true
 	tests := []struct {

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -107,6 +107,7 @@ type watcher struct {
 
 // NewWatcher initializes the watcher client to provide a events handler for
 // resource from the cluster (filtered to the given node)
+// Note: This watcher won't emit workqueue metrics. Use NewNamedWatcher to provide an explicit queue name.
 func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOptions, indexers cache.Indexers) (Watcher, error) {
 	return NewNamedWatcher("", client, resource, opts, indexers)
 }
@@ -205,6 +206,7 @@ func NewNamedWatcherWithInformer(
 // NewMetadataWatcher initializes a metadata-only watcher client to provide an events handler for
 // resource from the cluster (filtered to the given node).
 // Event handlers defined on this watcher receive PartialObjectMetadata resources.
+// Note: This watcher won't emit workqueue metrics. Use NewNamedWatcher to provide an explicit queue name.
 func NewMetadataWatcher(
 	client kubernetes.Interface,
 	metadataClient metadata.Interface,

--- a/kubernetes/watcher_test.go
+++ b/kubernetes/watcher_test.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	cachetest "k8s.io/client-go/tools/cache/testing"
+)
+
+func TestWatcherStartAndStop(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Pod{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Start())
+	watcher.Stop()
+}
+
+func TestWatcherHandlers(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Pod{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	require.NoError(t, err)
+
+	var added, updated, deleted bool
+
+	watcher.AddEventHandler(ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			added = true
+		},
+		UpdateFunc: func(obj interface{}) {
+			updated = true
+		},
+		DeleteFunc: func(obj interface{}) {
+			deleted = true
+		},
+	})
+
+	require.NoError(t, watcher.Start())
+	defer watcher.Stop()
+
+	pod := &Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			UID:             types.UID("poduid"),
+			Namespace:       "test",
+			ResourceVersion: "1",
+		},
+	}
+	// add a resource
+	listWatch.Add(pod)
+	assert.Eventually(t, func() bool {
+		return added
+	}, time.Second*5, time.Millisecond)
+
+	// update the resource
+	modifiedPod := pod.DeepCopy()
+	modifiedPod.SetResourceVersion("2")
+	listWatch.Modify(modifiedPod)
+	assert.Eventually(t, func() bool {
+		return updated
+	}, time.Second*5, time.Millisecond)
+
+	// delete the resource
+	listWatch.Delete(modifiedPod)
+	assert.Eventually(t, func() bool {
+		return deleted
+	}, time.Second*5, time.Millisecond)
+}
+
+func TestWatcherIsUpdated(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Pod{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	// set a custom IsUpdated that always returns true
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer,
+		WatchOptions{IsUpdated: func(old, new interface{}) bool {
+			return true
+		}})
+	require.NoError(t, err)
+
+	var updated bool
+
+	watcher.AddEventHandler(ResourceEventHandlerFuncs{
+		UpdateFunc: func(obj interface{}) {
+			updated = true
+		},
+	})
+
+	require.NoError(t, watcher.Start())
+	defer watcher.Stop()
+
+	pod := &Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			UID:       types.UID("poduid"),
+			Namespace: "test",
+		},
+	}
+	listWatch.Add(pod)
+
+	// update the resource, but don't actually change it
+	// with the default IsUpdated, our handler wouldn't be called, but with our custom one, it will
+	modifiedPod := pod.DeepCopy()
+	listWatch.Modify(modifiedPod)
+	assert.Eventually(t, func() bool {
+		return updated
+	}, time.Second*5, time.Millisecond)
+
+}
+
+func TestCachedObject(t *testing.T) {
+	t.Skip("Currently bugged, and not used anywhere")
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Namespace{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, watcher.Start())
+	defer watcher.Stop()
+
+	namespace := &Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			UID:             types.UID("poduid"),
+			Namespace:       "test",
+			ResourceVersion: "1",
+		},
+	}
+	listWatch.Add(namespace)
+	assert.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		assert.Equal(collectT, namespace, watcher.CachedObject())
+	}, time.Second*5, time.Millisecond)
+}


### PR DESCRIPTION
Introduce metadata-only watchers to the kubernetes package. These are useful if we only need to track metadata for a resource - a good example are ReplicaSets, for which we usually only care about the OwnerReferences. As a result, we only store the metadata, reducing steady-state memory consumption, but also only get updates involving metadata, reducing churn greatly in larger clusters.

The implementation introduces new constructors for the Watcher, allowing an informer to be passed in. Existing constructors are implemented using the new constructor, though none of the code actually changes. As a result, it is now possible to unit test the watcher, and I've added some basic unit tests for it.

We also add two helper functions:

- `GetKubernetesMetadataClient` creates a metadata-only kubernetes client, and is very similar to the existing `GetKubernetesClient`
- `RemoveUnnecessaryReplicaSetData` is a transform function that can be passed into an informer so it only stores the metadata we actually use

I tested these new functions in both beats and agent, in a kind cluster as well as one of our staging clusters.

This is part of the solution to https://github.com/elastic/elastic-agent/pull/5580.