### PR TITLE
github-actions: use them instead of buildkite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # GitHub CODEOWNERS definition
 # See: https://help.github.com/articles/about-codeowners/
 * @elastic/elastic-agent-data-plane
+
+# CI workflows
+/.github/workflows/ @elastic/observablt-ci

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+---
+name: setup
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: .go-version
+
+    - run: go install github.com/magefile/mage@v1.15.0
+      shell: bash
+
+    - run: go install gotest.tools/gotestsum@latest
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+---
+name: ci
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+  merge_group:
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          go-version-file: go.mod
+      - run: mage notice
+      - run: mage -v check
+
+  test:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-22.04', 'windows-2022', 'macos-15']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: gotestsum --format testname -- -v ./...
+
+  test-preview:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-24.04-arm', 'windows-11-arm']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: go test -v ./...


### PR DESCRIPTION
### What

- Use GitHub actions
- Add dependabot for GH actions

### Why

- https://buildkite.com/elastic/elastic-agent-autodiscover/builds/291 failed
- Run faster builds.
- Reduce environmental issues.
- Simplify the maintenance by using the [self-hosted](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) GitHub runners.

### Build times

From `9 minutes`, see [here](https://buildkite.com/elastic/elastic-agent-autodiscover/builds/293/waterfall), to `1min and 20 seconds`, see [here](https://github.com/elastic/elastic-agent-autodiscover/actions)

<img width="1664" alt="image" src="https://github.com/user-attachments/assets/745325d9-e804-4fd7-8f1a-026f7b62817f" />


vs 
