### PR TITLE
Replace global logger with local logger

### DIFF
--- a/docker/client.go
+++ b/docker/client.go
@@ -32,8 +32,8 @@ import (
 // NewClient builds and returns a new Docker client. On the first request the
 // client will negotiate the API version with the server unless
 // DOCKER_API_VERSION is set in the environment.
-func NewClient(host string, httpClient *http.Client, httpHeaders map[string]string) (*client.Client, error) {
-	log := logp.NewLogger("docker")
+func NewClient(host string, httpClient *http.Client, httpHeaders map[string]string, logger *logp.Logger) (*client.Client, error) {
+	log := logger.Named("docker")
 
 	opts := []client.Opt{
 		client.WithHost(host),

--- a/docker/watcher.go
+++ b/docker/watcher.go
@@ -141,7 +141,7 @@ func NewWatcher(log *logp.Logger, host string, tls *TLSConfig, storeShortID bool
 		}
 	}
 
-	client, err := NewClient(host, httpClient, nil)
+	client, err := NewClient(host, httpClient, nil, log)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/elastic/elastic-agent-libs v0.11.0
+	github.com/elastic/elastic-agent-libs v0.21.2
 	github.com/magefile/mage v1.13.0
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/elastic-agent-libs v0.11.0 h1:m9rnNE3BkBF2XJoqubqEbu/kbtKEBZ7pHCjDlxfVRH0=
-github.com/elastic/elastic-agent-libs v0.11.0/go.mod h1:5CR02awPrBr+tfmjBBK+JI+dMmHNQjpVY24J0wjbC7M=
+github.com/elastic/elastic-agent-libs v0.21.2 h1:r4Tokxx8OvFUVw28foiZT/WHwGUM7JFdlb4TVJ25v9M=
+github.com/elastic/elastic-agent-libs v0.21.2/go.mod h1:xSeIP3NtOIT4N2pPS4EyURmS1Q8mK0lWZ8Wd1Du6q3w=
 github.com/elastic/go-licenser v0.4.0 h1:jLq6A5SilDS/Iz1ABRkO6BHy91B9jBora8FwGRsDqUI=
 github.com/elastic/go-licenser v0.4.0/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
 github.com/elastic/go-ucfg v0.8.5 h1:4GB/rMpuh7qTcSFaxJUk97a/JyvFzhi6t+kaskTTLdM=

--- a/kubernetes/k8skeystore/kubernetes_keystore_test.go
+++ b/kubernetes/k8skeystore/kubernetes_keystore_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/elastic-agent-autodiscover/bus"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	v1 "k8s.io/api/core/v1"
@@ -96,7 +96,7 @@ func TestGetKeystoreAndRetrieveWithWrongKeyFormat(t *testing.T) {
 }
 
 func TestGetKeystoreAndRetrieveWithNoSecretsExistent(t *testing.T) {
-	logger := logp.NewLogger("test_k8s_secrets")
+	logger := logptest.NewTestingLogger(t, "test_k8s_secrets")
 	client := k8sfake.NewSimpleClientset()
 
 	kRegistry := NewKubernetesKeystoresRegistry(logger, client)
@@ -122,7 +122,7 @@ func TestGetKeystoreAndRetrieveWithWrongSecretValue(t *testing.T) {
 }
 
 func getKeystoreForWrongValue(t *testing.T) bus.KeystoreProvider {
-	logger := logp.NewLogger("test_k8s_secrets")
+	logger := logptest.NewTestingLogger(t, "test_k8s_secrets")
 	client := k8sfake.NewSimpleClientset()
 	secret := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/kubernetes/util_test.go
+++ b/kubernetes/util_test.go
@@ -24,10 +24,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +35,7 @@ import (
 
 func TestDiscoverKubernetesNode(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
-	logger := logp.NewLogger("autodiscover.node")
+	logger := logptest.NewTestingLogger(t, "autodiscover.node")
 	ge := errors.New("kubernetes: Node could not be discovered with any known method. Consider setting env var NODE_NAME")
 	tests := []struct {
 		host        string

--- a/kubernetes/watcher_test.go
+++ b/kubernetes/watcher_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func TestWatcherStartAndStop(t *testing.T) {
 	listWatch := cachetest.NewFakeControllerSource()
 	resource := &Pod{}
 	informer := cache.NewSharedInformer(listWatch, resource, 0)
-	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
 	require.NoError(t, err)
 	require.NoError(t, watcher.Start())
 	watcher.Stop()
@@ -46,7 +47,7 @@ func TestWatcherHandlers(t *testing.T) {
 	listWatch := cachetest.NewFakeControllerSource()
 	resource := &Pod{}
 	informer := cache.NewSharedInformer(listWatch, resource, 0)
-	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
 	require.NoError(t, err)
 
 	var added, updated, deleted bool
@@ -102,6 +103,7 @@ func TestWatcherIsUpdated(t *testing.T) {
 	informer := cache.NewSharedInformer(listWatch, resource, 0)
 	// set a custom IsUpdated that always returns true
 	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer,
+		logptest.NewTestingLogger(t, ""),
 		WatchOptions{IsUpdated: func(old, new interface{}) bool {
 			return true
 		}})
@@ -143,7 +145,7 @@ func TestCachedObject(t *testing.T) {
 	listWatch := cachetest.NewFakeControllerSource()
 	resource := &Namespace{}
 	informer := cache.NewSharedInformer(listWatch, resource, 0)
-	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, WatchOptions{})
+	watcher, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
 	require.NoError(t, err)
 
 	require.NoError(t, watcher.Start())

--- a/utils/hints.go
+++ b/utils/hints.go
@@ -87,14 +87,14 @@ func GetHintAsList(hints mapstr.M, key, config string) []string {
 }
 
 // GetProcessors gets processor definitions from the hints and returns a list of configs as a MapStr
-func GetProcessors(hints mapstr.M, key string) []mapstr.M {
+func GetProcessors(hints mapstr.M, key string, logger *logp.Logger) []mapstr.M {
 	processors := GetConfigs(hints, key, "processors")
 	for _, proc := range processors {
 		for key, value := range proc {
 			if str, ok := value.(string); ok {
 				cfg := mapstr.M{}
 				if err := json.Unmarshal([]byte(str), &cfg); err != nil {
-					logp.NewLogger(logName).Debugw("Unable to unmarshal json due to error", "error", err)
+					logger.Named(logName).Debugw("Unable to unmarshal json due to error", "error", err)
 					continue
 				}
 				proc[key] = cfg
@@ -155,13 +155,13 @@ func getStringAsList(input string) []string {
 }
 
 // GetHintAsConfigs can read a hint in the form of a stringified JSON and return a mapstr.M
-func GetHintAsConfigs(hints mapstr.M, key string) []mapstr.M {
+func GetHintAsConfigs(hints mapstr.M, key string, logger *logp.Logger) []mapstr.M {
 	if str := GetHintString(hints, key, "raw"); str != "" {
 		// check if it is a single config
 		if str[0] != '[' {
 			cfg := mapstr.M{}
 			if err := json.Unmarshal([]byte(str), &cfg); err != nil {
-				logp.NewLogger(logName).Debugw("Unable to unmarshal json due to error", "error", err)
+				logger.Named(logName).Debugw("Unable to unmarshal json due to error", "error", err)
 				return nil
 			}
 			return []mapstr.M{cfg}
@@ -169,7 +169,7 @@ func GetHintAsConfigs(hints mapstr.M, key string) []mapstr.M {
 
 		var cfg []mapstr.M
 		if err := json.Unmarshal([]byte(str), &cfg); err != nil {
-			logp.NewLogger(logName).Debugw("Unable to unmarshal json due to error", "error", err)
+			logger.Named(logName).Debugw("Unable to unmarshal json due to error", "error", err)
 			return nil
 		}
 		return cfg
@@ -188,11 +188,11 @@ func IsEnabled(hints mapstr.M, key string) bool {
 }
 
 // IsDisabled will return true when 'enabled' is **explicitly** set to false.
-func IsDisabled(hints mapstr.M, key string) bool {
+func IsDisabled(hints mapstr.M, key string, logger *logp.Logger) bool {
 	if value, err := hints.GetValue(fmt.Sprintf("%s.enabled", key)); err == nil {
 		enabled, err := strconv.ParseBool(value.(string))
 		if err != nil {
-			logp.NewLogger(logName).Debugw("Error parsing 'enabled' hint.",
+			logger.Named(logName).Debugw("Error parsing 'enabled' hint.",
 				"error", err, "autodiscover.hints", hints)
 			return false
 		}

--- a/utils/hints_test.go
+++ b/utils/hints_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -37,7 +38,7 @@ func TestGetProcessors(t *testing.T) {
 			},
 		},
 	}
-	procs := GetProcessors(hints, "co.elastic.logs")
+	procs := GetProcessors(hints, "co.elastic.logs", logptest.NewTestingLogger(t, ""))
 	assert.Equal(t, []mapstr.M{
 		mapstr.M{
 			"add_fields": mapstr.M{


### PR DESCRIPTION
Part of effort to get rid of global logger and replace them with local versions

See Issue https://github.com/elastic/ingest-dev/issues/5251