### PR TITLE
Reject restarting stopped Kubernetes watchers

### DIFF
--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -19,6 +19,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -47,6 +48,15 @@ const (
 var (
 	accessor = meta.NewAccessor()
 )
+
+// ErrWatcherStopped is returned by Start when the watcher has already been
+// stopped and cannot be restarted. The underlying Kubernetes SharedInformer is
+// one-shot: once its Run loop has exited, the informer, workqueue and context
+// are permanently unusable. Restarting such a watcher would silently succeed
+// (HasSynced remains true from the first run) while no further events are ever
+// delivered. Callers must create a fresh watcher instead of reusing a stopped
+// one; errors.Is can be used to detect this condition.
+var ErrWatcherStopped = errors.New("kubernetes watcher has been stopped and cannot be restarted")
 
 // Watcher watches Kubernetes resources events
 type Watcher interface {
@@ -282,6 +292,23 @@ func (w *watcher) CachedObject() runtime.Object {
 
 // Start watching pods
 func (w *watcher) Start() error {
+	// A stopped watcher must never be restarted. The Kubernetes SharedInformer
+	// is one-shot; once Run has exited it rejects a second invocation with
+	// "run more than once is not allowed" and returns immediately, yet
+	// WaitForCacheSync below would still succeed because HasSynced stays true
+	// from the first run. That turns an invalid restart into a silent no-op
+	// against a frozen store. Detect the terminal lifecycle state up front and
+	// fail loudly so callers construct a fresh watcher instead.
+	if w.informer.IsStopped() || w.queue.ShuttingDown() || w.ctx.Err() != nil {
+		return fmt.Errorf(
+			"%w (informer_stopped=%t, queue_shutting_down=%t, context_error=%v)",
+			ErrWatcherStopped,
+			w.informer.IsStopped(),
+			w.queue.ShuttingDown(),
+			w.ctx.Err(),
+		)
+	}
+
 	go w.informer.Run(w.ctx.Done())
 
 	if !cache.WaitForCacheSync(w.ctx.Done(), w.informer.HasSynced) {

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -52,10 +52,7 @@ var (
 // ErrWatcherStopped is returned by Start when the watcher has already been
 // stopped and cannot be restarted. The underlying Kubernetes SharedInformer is
 // one-shot: once its Run loop has exited, the informer, workqueue and context
-// are permanently unusable. Restarting such a watcher would silently succeed
-// (HasSynced remains true from the first run) while no further events are ever
-// delivered. Callers must create a fresh watcher instead of reusing a stopped
-// one; errors.Is can be used to detect this condition.
+// are permanently unusable.
 var ErrWatcherStopped = errors.New("kubernetes watcher has been stopped and cannot be restarted")
 
 // Watcher watches Kubernetes resources events
@@ -305,7 +302,7 @@ func (w *watcher) Start() error {
 			ErrWatcherStopped,
 			w.informer.IsStopped(),
 			w.queue.ShuttingDown(),
-			w.ctx.Err(),
+			w.ctx.Err(), //nolint:errorlint // Another error is wrapped
 		)
 	}
 

--- a/kubernetes/watcher_test.go
+++ b/kubernetes/watcher_test.go
@@ -19,7 +19,6 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -55,7 +54,13 @@ func TestWatcherStopPreventsRestart(t *testing.T) {
 	listWatch := cachetest.NewFakeControllerSource()
 	resource := &Pod{}
 	informer := cache.NewSharedInformer(listWatch, resource, 0)
-	w, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
+	w, err := NewNamedWatcherWithInformer(
+		"test",
+		client,
+		resource,
+		informer,
+		logptest.NewTestingLogger(t, ""),
+		WatchOptions{})
 	require.NoError(t, err)
 
 	require.NoError(t, w.Start())
@@ -64,12 +69,12 @@ func TestWatcherStopPreventsRestart(t *testing.T) {
 	// Give the informer's Run loop time to observe the cancelled context and
 	// mark itself stopped so IsStopped() reflects the terminal state.
 	assert.Eventually(t, func() bool {
+		//nolint:errcheck // It's a test, it can panic on failure
 		return w.(*watcher).informer.IsStopped()
 	}, time.Second*5, time.Millisecond)
 
-	err = w.Start()
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+	// Try starting watcher again and check for the correct error returned
+	require.ErrorIs(t, w.Start(), ErrWatcherStopped, "expected ErrWatcherStopped, got: %v", err)
 }
 
 // TestWatcherStartRejectsInvalidLifecycleStates verifies that Start refuses to
@@ -77,13 +82,19 @@ func TestWatcherStopPreventsRestart(t *testing.T) {
 // look healthy.
 func TestWatcherStartRejectsInvalidLifecycleStates(t *testing.T) {
 	newWatcher := func(t *testing.T) *watcher {
-		t.Helper()
 		client := fake.NewSimpleClientset()
 		listWatch := cachetest.NewFakeControllerSource()
 		resource := &Pod{}
 		informer := cache.NewSharedInformer(listWatch, resource, 0)
-		w, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
+		w, err := NewNamedWatcherWithInformer(
+			"test",
+			client,
+			resource,
+			informer,
+			logptest.NewTestingLogger(t, ""),
+			WatchOptions{})
 		require.NoError(t, err)
+		//nolint:errcheck // It's a test, we know the underlying type
 		return w.(*watcher)
 	}
 
@@ -93,38 +104,36 @@ func TestWatcherStartRejectsInvalidLifecycleStates(t *testing.T) {
 		require.False(t, w.informer.IsStopped())
 		require.NoError(t, w.ctx.Err())
 
-		err := w.Start()
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+		require.ErrorIs(t, w.Start(), ErrWatcherStopped, "expected ErrWatcherStopped")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
 		w := newWatcher(t)
-		w.stop()
+		w.stop() // context cancel func
 		require.False(t, w.informer.IsStopped())
 		require.False(t, w.queue.ShuttingDown())
 		require.ErrorIs(t, w.ctx.Err(), context.Canceled)
 
-		err := w.Start()
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+		require.ErrorIs(t, w.Start(), ErrWatcherStopped, "expected ErrWatcherStopped")
 	})
 
 	t.Run("informer stopped", func(t *testing.T) {
 		w := newWatcher(t)
 		stopCh := make(chan struct{})
+
 		go w.informer.Run(stopCh)
 		require.Eventually(t, w.informer.HasSynced, time.Second*5, time.Millisecond)
+
 		close(stopCh)
+
 		require.Eventually(t, func() bool {
 			return w.informer.IsStopped()
 		}, time.Second*5, time.Millisecond)
+
 		require.False(t, w.queue.ShuttingDown())
 		require.NoError(t, w.ctx.Err())
 
-		err := w.Start()
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+		require.ErrorIs(t, w.Start(), ErrWatcherStopped, "expected ErrWatcherStopped")
 	})
 }
 

--- a/kubernetes/watcher_test.go
+++ b/kubernetes/watcher_test.go
@@ -18,6 +18,8 @@
 package kubernetes
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -41,6 +43,89 @@ func TestWatcherStartAndStop(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, watcher.Start())
 	watcher.Stop()
+}
+
+// TestWatcherStopPreventsRestart reproduces the shared-informer lifecycle bug:
+// a watcher that has been started and stopped must never be restarted, because
+// the underlying one-shot SharedInformer would refuse to run again while
+// WaitForCacheSync still reports success from the first run. Start must fail
+// with ErrWatcherStopped instead of silently returning a frozen watcher.
+func TestWatcherStopPreventsRestart(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Pod{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	w, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, w.Start())
+	w.Stop()
+
+	// Give the informer's Run loop time to observe the cancelled context and
+	// mark itself stopped so IsStopped() reflects the terminal state.
+	assert.Eventually(t, func() bool {
+		return w.(*watcher).informer.IsStopped()
+	}, time.Second*5, time.Millisecond)
+
+	err = w.Start()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+}
+
+// TestWatcherStartRejectsInvalidLifecycleStates verifies that Start refuses to
+// run when any single terminal lifecycle signal is present, even if the others
+// look healthy.
+func TestWatcherStartRejectsInvalidLifecycleStates(t *testing.T) {
+	newWatcher := func(t *testing.T) *watcher {
+		t.Helper()
+		client := fake.NewSimpleClientset()
+		listWatch := cachetest.NewFakeControllerSource()
+		resource := &Pod{}
+		informer := cache.NewSharedInformer(listWatch, resource, 0)
+		w, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
+		require.NoError(t, err)
+		return w.(*watcher)
+	}
+
+	t.Run("queue shutting down", func(t *testing.T) {
+		w := newWatcher(t)
+		w.queue.ShutDown()
+		require.False(t, w.informer.IsStopped())
+		require.NoError(t, w.ctx.Err())
+
+		err := w.Start()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		w := newWatcher(t)
+		w.stop()
+		require.False(t, w.informer.IsStopped())
+		require.False(t, w.queue.ShuttingDown())
+		require.ErrorIs(t, w.ctx.Err(), context.Canceled)
+
+		err := w.Start()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+	})
+
+	t.Run("informer stopped", func(t *testing.T) {
+		w := newWatcher(t)
+		stopCh := make(chan struct{})
+		go w.informer.Run(stopCh)
+		require.Eventually(t, w.informer.HasSynced, time.Second*5, time.Millisecond)
+		close(stopCh)
+		require.Eventually(t, func() bool {
+			return w.informer.IsStopped()
+		}, time.Second*5, time.Millisecond)
+		require.False(t, w.queue.ShuttingDown())
+		require.NoError(t, w.ctx.Err())
+
+		err := w.Start()
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrWatcherStopped), "expected ErrWatcherStopped, got: %v", err)
+	})
 }
 
 func TestWatcherHandlers(t *testing.T) {


### PR DESCRIPTION
Return an explicit lifecycle error instead of silently accepting an invalid second SharedInformer start.

Human-Reviewed: Yes
Tool: Cursor Agent
Assisted-by: Claude Opus 4.8 Thinking High; Claude Sonnet 5 Thinking High